### PR TITLE
rm msisdn from regiter confirm

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -129,13 +129,9 @@ paths:
             schema:
               type: object
               required:
-                - msisdn
+                - registration_id
                 - code
               properties:
-                msisdn:
-                  type: string
-                  description: "9 digit phone number with prefix +48"
-                  example: "+48123123123"
                 code:
                   type: string
                   description: "code from sms"

--- a/functions/confirm_registration/main.py
+++ b/functions/confirm_registration/main.py
@@ -17,7 +17,6 @@ def confirm_registration(request):
         ), 405
 
     if not request.is_json \
-            or "msisdn" not in request.get_json() \
             or "code" not in request.get_json() \
             or "registration_id" not in request.get_json():
         return jsonify(
@@ -27,11 +26,10 @@ def confirm_registration(request):
         ), 422
     request_data = request.get_json()
 
-    msisdn = request_data["msisdn"]
     code = request_data["code"]
     registration_id = request_data["registration_id"]
 
-    entity = _get_from_datastore(msisdn)
+    entity = _get_from_datastore(registration_id)
 
     if not entity or entity["code"] != code or entity["registration_id"] != registration_id:
         return jsonify(
@@ -52,9 +50,9 @@ def confirm_registration(request):
     )
 
 
-def _get_from_datastore(msisdn: str) -> Optional[Entity]:
+def _get_from_datastore(registration_id: str) -> Optional[Entity]:
     kind = "Device"
-    device_key = datastore_client.key(kind, f"{msisdn}")
+    device_key = datastore_client.key(kind, f"{registration_id}")
     return datastore_client.get(key=device_key)
 
 

--- a/functions/register_device/main.py
+++ b/functions/register_device/main.py
@@ -83,7 +83,7 @@ def _check_phone_number(msisdn: str):
 
 def _save_to_datastore(code: str, msisdn: str, date: datetime, registration_id: str):
     kind = 'Device'
-    device_key = datastore_client.key(kind, f'{msisdn}')
+    device_key = datastore_client.key(kind, f'{registration_id}')
 
     device = datastore.Entity(key=device_key)
     device.update(


### PR DESCRIPTION
Usunięcie msisdn z parametrów requstu do register_confirm. Registration musi być trzymane pod kluczem register_id w związku z tym.