### PR TITLE
MSISDN format, ordering of returned registration entries

### DIFF
--- a/functions/register/main.py
+++ b/functions/register/main.py
@@ -26,8 +26,6 @@ DATA_STORE_REGISTRATION_KIND = "Registrations"
 REGISTRATION_STATUS_PENDING = "pending"
 REGISTRATION_STATUS_INCORRECT = "incorrect"
 
-PHONE_NUMBER_ALLOWED_CHARS = "+0123456789"
-
 datastore_client = datastore.Client()
 publisher = pubsub_v1.PublisherClient()
 

--- a/functions/register/main.py
+++ b/functions/register/main.py
@@ -86,7 +86,7 @@ def _is_request_valid(request: Request) -> Tuple[bool, Optional[Tuple[Response, 
 
 
 def _check_phone_number(msisdn: str):
-    msisdn = re.sub('[^0-9,+]', '', msisdn)
+    msisdn = re.sub("[^0-9,+]", "", msisdn)
     if (not msisdn.startswith("+48") and len(msisdn) != 12) or (not msisdn.startswith("48") and len(msisdn) != 11):
         logging.warning(f"check_phone_number: invalid phone number: {msisdn}")
         return False

--- a/functions/register/main.py
+++ b/functions/register/main.py
@@ -87,11 +87,10 @@ def _is_request_valid(request: Request) -> Tuple[bool, Optional[Tuple[Response, 
 
 def _check_phone_number(msisdn: str):
     msisdn = re.sub("[^0-9,+]", "", msisdn)
-    if re.match("^\+48[0-9]{9}$", msisdn):
-        logging.warning(f"check_phone_number: invalid phone number: {msisdn}")
-        return False
-
-    return True
+    if re.match(r"^\+48[0-9]{9}$", msisdn):
+        return True
+    logging.warning(f"check_phone_number: invalid phone number: {msisdn}")
+    return False
 
 
 def _is_too_many_requests_for(field: str, value: str, limit: int) -> bool:

--- a/functions/register/main.py
+++ b/functions/register/main.py
@@ -87,7 +87,7 @@ def _is_request_valid(request: Request) -> Tuple[bool, Optional[Tuple[Response, 
 
 def _check_phone_number(msisdn: str):
     msisdn = re.sub("[^0-9,+]", "", msisdn)
-    if (not msisdn.startswith("+48") and len(msisdn) != 12) or (not msisdn.startswith("48") and len(msisdn) != 11):
+    if re.match("^\+48[0-9]{9}$", msisdn):
         logging.warning(f"check_phone_number: invalid phone number: {msisdn}")
         return False
 

--- a/functions/register/main.py
+++ b/functions/register/main.py
@@ -87,8 +87,7 @@ def _is_request_valid(request: Request) -> Tuple[bool, Optional[Tuple[Response, 
 
 def _check_phone_number(msisdn: str):
     msisdn = re.sub('[^0-9,+]', '', msisdn)
-    if (not msisdn.startswith("+48") and len(msisdn) != 12) \
-            or (not msisdn.startswith("48") and len(msisdn) != 11):
+    if (not msisdn.startswith("+48") and len(msisdn) != 12) or (not msisdn.startswith("48") and len(msisdn) != 11):
         logging.warning(f"check_phone_number: invalid phone number: {msisdn}")
         return False
 


### PR DESCRIPTION
1. More robust way to check MSISDN correctness 
2. Always order returned entries by date - _get_pending_registration_code returns first element, so order has to be deterministic.

Notes:
1. Don't mix polish and english in error messages. Use status  codes understandable by frontend.
2. I don't see anywhere expired data being removed for registration. Maybe consider paritioned tables (by YEAR_MONTH_DAY_HOUR) with TTL set which is going to clean up for you?
https://cloud.google.com/bigquery/docs/partitioned-tables