### PR TITLE
Use GitHub Actions for basic code checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, C812
+max-line-length = 127
+select = B,C,E,F,W
+max-complexity=10

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: ProteGO
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r tests/requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Check formatting with black
+      run: |
+        pip install black
+        black --diff --check .

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,10 +27,7 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --show-source --statistics
     - name: Check formatting with black
       run: |
         pip install black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+default_language_version:
+    python: python3.7
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Przed przystąpieniem do instalacji należy wykonać następujące kroki:
 
 2. Zainstalować narzędzie `terraform` zgodnie z instrukcją na [learn.hashicorp.com/terraform/getting-started/install](https://learn.hashicorp.com/terraform/getting-started/install.html#installing-terraform)
 
+Dodatkowo możesz lokalnie [zainstalować pre-commit](https://pre-commit.com/#install) przez `pip install pre-commit && pre-commit install`.
+Pomoże on upewnić się o poprawności składniowej, formatowaniu kodu i tym podobnych przed zachowaniem zmian w repozytorium.
+
 ### Instalacja ProteGO na serwerze
 
 1. Używając narzędzia `gcloud` Należy zalogować się do **GCP** przy użyciu strony logowana lub Service Account z odpowiednimi uprawnieniami:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 127
+target-version = ['py37']


### PR DESCRIPTION
Lets get some code checking during pull requests evaluation.  
Actual tests (ie unittests) are not executed, as those need special infra.

There is another pull request ( https://github.com/ProteGO-app/backend/pull/59 ) with reformatted code to make both PRs easily understandable and code checks green.

Proposed changes heavily base on default config supplied by GitHub.